### PR TITLE
feat: prover

### DIFF
--- a/src/components/bytes/mod.rs
+++ b/src/components/bytes/mod.rs
@@ -9,7 +9,7 @@ use super::TraceSize;
 mod constraints;
 mod trace;
 
-pub use constraints::BytesComponent;
+pub use constraints::{BytesComponent, BytesEval};
 pub use trace::{interaction_trace, preprocessed_trace, trace};
 
 /// U8 Operations
@@ -29,7 +29,7 @@ pub const LOG_SIZE: u32 = 2 * ELEMENT_BITS;
 pub const N_PREPROCESSED_COLUMNS: usize = 4;
 
 /// Bytes Component is the PreProcessed Table for Binary Operations b/w pair of ELEMENT_BITS elements.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum BytesPreProcessedColumn {
     A = 0,
     B = 1,
@@ -38,7 +38,11 @@ pub enum BytesPreProcessedColumn {
 }
 
 impl TraceSize for BytesPreProcessedColumn {
+    /// A, B, CAnd, CLessThanU8, is_first
+    const PREPROCESSED_COLS: usize = 5;
+    /// multiplicities of and, less than, and range check operations
     const MAIN_COLS: usize = 3;
+    /// (and, less than) batched column + range check interaction column
     const INTERACTION_COLS: usize = 2 * SECURE_EXTENSION_DEGREE;
 }
 

--- a/src/components/bytes/mod.rs
+++ b/src/components/bytes/mod.rs
@@ -26,7 +26,7 @@ pub const ELEMENT_BITS: u32 = 8;
 pub const LOG_SIZE: u32 = 2 * ELEMENT_BITS;
 
 /// Number of PreProcessed Columns for Bytes Component.
-pub const N_PREPROCESSED_COLUMNS: usize = 4;
+pub const N_PREPROCESSED_COLUMNS: usize = 5;
 
 /// Bytes Component is the PreProcessed Table for Binary Operations b/w pair of ELEMENT_BITS elements.
 #[derive(Debug, Clone)]
@@ -35,6 +35,7 @@ pub enum BytesPreProcessedColumn {
     B = 1,
     CAnd = 2,
     CLessThanU8 = 3,
+    IsFirst = 4,
 }
 
 impl TraceSize for BytesPreProcessedColumn {
@@ -59,6 +60,7 @@ impl BytesPreProcessedColumn {
             Self::B => 1,
             Self::CAnd => 2,
             Self::CLessThanU8 => 3,
+            Self::IsFirst => 4,
         }
     }
 }

--- a/src/components/bytes/trace.rs
+++ b/src/components/bytes/trace.rs
@@ -35,7 +35,9 @@ pub fn preprocessed_trace() -> ColumnVec<CircleEvaluation<SimdBackend, BaseField
 {
     let _span = span!(Level::INFO, "Bytes: Preprocessed Trace").entered();
     // The Trace is populated
-    let mut trace = unsafe { ComponentTrace::<N_PREPROCESSED_COLUMNS>::uninitialized(LOG_SIZE) };
+    // The Trace is filled for a, b, c_and, c_less_than and later is_first is added
+    let mut trace =
+        unsafe { ComponentTrace::<{ N_PREPROCESSED_COLUMNS - 1 }>::uninitialized(LOG_SIZE) };
 
     // values from 0 to 2^LOG_SIZE
     let values: Vec<_> = (0..(1 << LOG_SIZE)).collect();

--- a/src/components/insertions/constraints.rs
+++ b/src/components/insertions/constraints.rs
@@ -75,7 +75,7 @@ pub struct InsertionsEval<S> {
 ///   10. Ensure that the resultant root hash from updating the low leaf is equal to the root contained in inactive leaf's merkle path.
 ///   11. Verify the Merkle Proof of the Inactive Leaf.
 ///   12. Update the Inactive Leaf's value to the inserted leaf using the updated_merkle_path.
-///   13. Ensure that the final state's count is equal to the initial state's count minus 1.
+///   13. Ensure that the final state's count is equal to the initial state's count plus 1.
 ///   14. Verify that the final root hash of the final state is equal to the root hash in the merkle path of the updated leaf.
 ///   15. The Priority must be updated only if the low leaf is the first leaf in the tree.
 ///       - The priority of the leaf will change only if the low leaf is the first leaf in the tree.

--- a/src/components/insertions/mod.rs
+++ b/src/components/insertions/mod.rs
@@ -1,15 +1,26 @@
-use stwo_prover::core::fields::{m31::BaseField, secure_column::SECURE_EXTENSION_DEGREE};
+use stwo_prover::{
+    constraint_framework::FrameworkComponent,
+    core::fields::{m31::BaseField, secure_column::SECURE_EXTENSION_DEGREE},
+};
 
-use crate::{executor::instruction::N_INSTRUCTION_FELTS, imt::MERKLE_HEIGHT};
+use crate::{
+    executor::instruction::N_INSTRUCTION_FELTS,
+    imt::{
+        side::{Buy, Sell},
+        MERKLE_HEIGHT,
+    },
+};
 
 use super::TraceSize;
 
 mod constraints;
 mod trace;
 
+pub use constraints::InsertionsEval;
 pub use trace::{interaction_trace, preprocessed_trace, trace};
 
-// pub use trace::{interaction_trace, preprocessed_trace, trace};
+pub type BuyInsertionComponent = FrameworkComponent<InsertionsEval<Buy>>;
+pub type SellInsertionComponent = FrameworkComponent<InsertionsEval<Sell>>;
 
 /// Insertion Instructions
 pub type Insertions = Vec<[BaseField; InsertionsColumn::MAIN_COLS]>;
@@ -21,6 +32,8 @@ pub type Insertions = Vec<[BaseField; InsertionsColumn::MAIN_COLS]>;
 pub struct InsertionsColumn;
 
 impl TraceSize for InsertionsColumn {
+    /// is_first column
+    const PREPROCESSED_COLS: usize = 1;
     const MAIN_COLS: usize = N_INSTRUCTION_FELTS;
     /// number of poseidon hashes: 4 times for leaf hashes
     ///     - 1 for low_merkle_proof

--- a/src/components/insertions/trace.rs
+++ b/src/components/insertions/trace.rs
@@ -1,19 +1,20 @@
-use crate::components::less_than::{LessThanElements, StrictLessThanElements};
-use crate::components::poseidon::PoseidonElements;
-use crate::executor::flatten_single;
-use crate::executor::instruction::InstructionElements;
-use crate::hash::N_ELEMENTS;
-use crate::imt::leaf::LeafColumn;
-use crate::imt::side::Side;
-use crate::imt::N_U64_FELTS;
 use crate::{
-    components::{Claim, InteractionClaim, TraceSize},
-    executor::instruction::InstructionColumn,
+    components::{
+        less_than::{LessThanElements, StrictLessThanElements},
+        poseidon::PoseidonElements,
+        trace_utils::{
+            add_interaction_col, add_less_than_interaction_col, add_merkle_interaction_col,
+        },
+        Claim, InteractionClaim, TraceSize,
+    },
+    executor::{flatten_single, instruction::InstructionColumn, instruction::InstructionElements},
     flatten,
-    hash::{N_HASH, N_STATE},
-    imt::{side::OrderSide, MERKLE_HEIGHT, N_LEAF_FELTS},
+    hash::{N_ELEMENTS, N_HASH, N_STATE},
+    imt::{
+        leaf::LeafColumn, side::OrderSide, side::Side, MERKLE_HEIGHT, N_LEAF_FELTS, N_U64_FELTS,
+    },
 };
-use itertools::{chain, Itertools};
+use itertools::Itertools;
 use num_traits::{One, Zero};
 use rayon::{
     iter::{IndexedParallelIterator, ParallelIterator},
@@ -22,12 +23,12 @@ use rayon::{
 use std::array;
 use stwo_air_utils::trace::component_trace::ComponentTrace;
 use stwo_prover::{
-    constraint_framework::{logup::LogupTraceGenerator, preprocessed_columns::IsFirst, Relation},
+    constraint_framework::{logup::LogupTraceGenerator, preprocessed_columns::IsFirst},
     core::{
         backend::{
             simd::{
                 column::BaseColumn,
-                m31::{PackedBaseField, LOG_N_LANES, N_LANES},
+                m31::{PackedBaseField, N_LANES},
                 qm31::PackedSecureField,
                 SimdBackend,
             },
@@ -282,96 +283,4 @@ pub fn interaction_trace<S: OrderSide>(
     );
     let (trace, claimed_sum) = logup_gen.finalize_last();
     (trace, InteractionClaim::new(claimed_sum))
-}
-
-/// add_interaction_col adds an interaction column to the logup generator for the given lookup elements in the given columns
-fn add_interaction_col<X: Relation<PackedBaseField, PackedSecureField>>(
-    logup_gen: &mut LogupTraceGenerator,
-    cols: &[&Vec<PackedBaseField>],
-    is_real: &Vec<PackedBaseField>,
-    log_size: u32,
-    lookup_elements: &X,
-    mult: PackedSecureField,
-) {
-    let mut col_gen = logup_gen.new_col();
-    for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {
-        let values1: Vec<PackedBaseField> = cols.iter().map(|col| col[vec_row]).collect();
-        let p1 = lookup_elements.combine(&values1);
-        col_gen.write_frac(vec_row, mult * is_real[vec_row], p1);
-    }
-    col_gen.finalize_col();
-}
-
-/// add_less_than_interaction_col adds an interaction column to the logup generator for the given a and b columns
-/// for strict less than comparison lookup elements must be StrictLessThanElements
-/// for less than comparison lookup elements must be LessThanElements
-fn add_less_than_interaction_col<R: Relation<PackedBaseField, PackedSecureField>>(
-    logup_gen: &mut LogupTraceGenerator,
-    col_a: &[&Vec<PackedBaseField>],
-    col_b: &[&Vec<PackedBaseField>],
-    is_real: &Vec<PackedBaseField>,
-    log_size: u32,
-    lookup_elements: &R,
-) {
-    let mut col_gen = logup_gen.new_col();
-    for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {
-        let a: Vec<PackedBaseField> = col_a.iter().map(|col| col[vec_row]).collect();
-        let b: Vec<PackedBaseField> = col_b.iter().map(|col| col[vec_row]).collect();
-        let c = PackedBaseField::one();
-        let values = chain!(a.into_iter(), b.into_iter(), std::iter::once(c)).collect_vec();
-        let p1 = lookup_elements.combine(&values);
-        col_gen.write_frac(vec_row, PackedSecureField::one() * is_real[vec_row], p1);
-    }
-    col_gen.finalize_col();
-}
-
-/// add_merkle_interaction_col adds an interaction column to the logup generator for the current and sibling columns
-/// the left and right values are determined by the index column
-/// [left, right, hash] -> lookup_elements
-fn add_merkle_interaction_col<X: Relation<PackedBaseField, PackedSecureField>>(
-    logup_gen: &mut LogupTraceGenerator,
-    curr: &[&Vec<PackedBaseField>],
-    sibling: &[&Vec<PackedBaseField>],
-    hash: &[&Vec<PackedBaseField>],
-    index: &Vec<PackedBaseField>,
-    is_real: &Vec<PackedBaseField>,
-    log_size: u32,
-    lookup_elements: &X,
-) {
-    let mut col_gen = logup_gen.new_col();
-    for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {
-        let cur: Vec<PackedBaseField> = curr.iter().map(|col| col[vec_row]).collect();
-        let sib: Vec<PackedBaseField> = sibling.iter().map(|col| col[vec_row]).collect();
-        let hash: Vec<PackedBaseField> = hash.iter().map(|col| col[vec_row]).collect();
-        let index: PackedBaseField = index[vec_row];
-        let (mut left, right): (Vec<PackedBaseField>, Vec<PackedBaseField>) = cur
-            .into_iter()
-            .zip(sib.into_iter())
-            .map(|(a, b)| {
-                let a = a.to_array();
-                let b = b.to_array();
-                let index = index.to_array();
-                let mut left = [BaseField::zero(); N_LANES];
-                let mut right = [BaseField::zero(); N_LANES];
-                for i in 0..N_LANES {
-                    if index[i] == BaseField::zero() {
-                        left[i] = a[i];
-                        right[i] = b[i];
-                    } else {
-                        left[i] = b[i];
-                        right[i] = a[i];
-                    }
-                }
-                (
-                    PackedBaseField::from_array(left),
-                    PackedBaseField::from_array(right),
-                )
-            })
-            .unzip();
-        left.extend(right);
-        left.extend(hash);
-        let p1 = lookup_elements.combine(&left);
-        col_gen.write_frac(vec_row, PackedSecureField::one() * is_real[vec_row], p1);
-    }
-    col_gen.finalize_col();
 }

--- a/src/components/insertions/trace.rs
+++ b/src/components/insertions/trace.rs
@@ -66,7 +66,7 @@ pub fn trace<S: OrderSide>(
     let mut dummy = insertions[0];
     dummy[InstructionColumn::IS_REAL] = BaseField::zero();
     for _ in 0..(1 << log_size) - insertions.len() {
-        insertions.push(insertions[0]);
+        insertions.push(dummy);
     }
     let mut trace = ComponentTrace::<{ InsertionsColumn::MAIN_COLS }>::zeroed(log_size);
     trace
@@ -164,7 +164,7 @@ pub fn interaction_trace<S: OrderSide>(
     );
 
     // Constraint 3 in constraints.rs
-    // low_time < next_time
+    // next_time < inserted_time
     add_less_than_interaction_col(
         &mut logup_gen,
         &next_time,

--- a/src/components/insertions/trace.rs
+++ b/src/components/insertions/trace.rs
@@ -266,6 +266,7 @@ pub fn interaction_trace<S: OrderSide>(
                     is_real,
                     log_size,
                     poseidon_elements,
+                    PackedSecureField::one()
                 );
                 curr = hash.clone();
             }

--- a/src/components/less_than/mod.rs
+++ b/src/components/less_than/mod.rs
@@ -11,7 +11,7 @@ mod constraints;
 mod trace;
 
 pub use constraints::LessThanEval;
-pub use trace::{interaction_trace_eval, preprocessed_trace, trace_eval};
+pub use trace::{interaction_trace, preprocessed_trace, trace};
 
 /// LessThanComponent represents the LessThan component
 pub type StrictLessThanComponent = FrameworkComponent<LessThanEval<true>>;
@@ -103,7 +103,7 @@ mod tests {
         constraint_framework::{assert_constraints, FrameworkEval},
         core::{channel::Blake2sChannel, pcs::TreeVec, poly::circle::CanonicCoset},
     };
-    use trace::{interaction_trace_eval, preprocessed_trace, trace_eval};
+    use trace::{interaction_trace, preprocessed_trace, trace};
     use tracing::{span, Level};
 
     use crate::{
@@ -123,15 +123,11 @@ mod tests {
     ) {
         let log_size = (less_than_operations.len() - 1).ilog2() + 1;
         let constant_trace = preprocessed_trace(log_size);
-        let (trace, claim) = trace_eval::<STRICT>(less_than_operations);
+        let (trace, claim) = trace::<STRICT>(less_than_operations);
         let (interaction_trace, interaction_claim) = if STRICT {
-            interaction_trace_eval::<STRICT, _>(
-                &trace,
-                less_than_u8_elements,
-                strict_less_than_elements,
-            )
+            interaction_trace::<STRICT, _>(&trace, less_than_u8_elements, strict_less_than_elements)
         } else {
-            interaction_trace_eval::<STRICT, _>(&trace, less_than_u8_elements, less_than_elements)
+            interaction_trace::<STRICT, _>(&trace, less_than_u8_elements, less_than_elements)
         };
 
         let trace = TreeVec::new(vec![constant_trace, trace, interaction_trace]);

--- a/src/components/less_than/mod.rs
+++ b/src/components/less_than/mod.rs
@@ -1,7 +1,7 @@
 use crate::types::N_U64_LIMBS;
 use std::array;
 use stwo_prover::{
-    constraint_framework::EvalAtRow,
+    constraint_framework::{EvalAtRow, FrameworkComponent},
     core::fields::{m31::BaseField, secure_column::SECURE_EXTENSION_DEGREE},
     relation,
 };
@@ -10,7 +10,12 @@ use super::TraceSize;
 mod constraints;
 mod trace;
 
+pub use constraints::LessThanEval;
 pub use trace::{interaction_trace_eval, preprocessed_trace, trace_eval};
+
+/// LessThanComponent represents the LessThan component
+pub type StrictLessThanComponent = FrameworkComponent<LessThanEval<true>>;
+pub type LessThanComponent = FrameworkComponent<LessThanEval<false>>;
 
 /// Less Than Operations
 pub type LessThanOperations = Vec<[BaseField; LessThanColumn::MAIN_COLS]>;
@@ -73,11 +78,13 @@ impl LessThanColumn {
 }
 
 impl TraceSize for LessThanColumn {
+    // is_first column
+    const PREPROCESSED_COLS: usize = 1;
     // last field's index + offset
     const MAIN_COLS: usize = Self::IS_REAL + 1;
     // 1 Interaction Column for LessThanU8 check
     // 1 Interaction Column for yielding the result
-    const INTERACTION_COLS: usize = 2 * SECURE_EXTENSION_DEGREE;
+    const INTERACTION_COLS: usize = SECURE_EXTENSION_DEGREE;
 }
 
 // A Total of 17 elements are "used" or "yielded" for the less than operation

--- a/src/components/less_than/trace.rs
+++ b/src/components/less_than/trace.rs
@@ -31,7 +31,7 @@ pub fn preprocessed_trace(
 }
 
 /// Trace for the Less Than Operations, each row consisting of a LessThanOp
-pub fn trace_eval<const STRICT: bool>(
+pub fn trace<const STRICT: bool>(
     mut less_than_operations: LessThanOperations,
 ) -> (
     ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>,
@@ -69,10 +69,7 @@ pub fn trace_eval<const STRICT: bool>(
 
 // Interaction Trace, "use" the LessThanU8Elements for comparison_bytes
 // and "yield" the LessThanElements for the actual comparison results
-pub fn interaction_trace_eval<
-    const STRICT: bool,
-    R: Relation<PackedBaseField, PackedSecureField>,
->(
+pub fn interaction_trace<const STRICT: bool, R: Relation<PackedBaseField, PackedSecureField>>(
     trace: &ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>,
     less_than_u8_elements: &LessThanU8Elements,
     less_than_elements: &R,

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -17,6 +17,8 @@ pub mod bytes;
 pub mod insertions;
 pub mod less_than;
 pub mod poseidon;
+pub mod processor;
+pub(crate) mod trace_utils;
 
 /// Const trait that defines the number of columns in the trace table
 pub trait TraceSize {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,17 +1,37 @@
-use num_traits::{One, Zero};
 use std::{marker::PhantomData, vec};
-use stwo_prover::core::{
-    backend::{
-        simd::{
-            column::BaseColumn,
-            m31::{PackedBaseField, LOG_N_LANES, N_LANES},
+
+use num_traits::{One, Zero};
+use stwo_prover::{
+    constraint_framework::TraceLocationAllocator,
+    core::{
+        air::{Component, ComponentProver},
+        backend::{
+            simd::{
+                column::BaseColumn,
+                m31::{PackedBaseField, LOG_N_LANES, N_LANES},
+                SimdBackend,
+            },
+            Column,
         },
-        Column,
+        channel::Channel,
+        fields::{m31::BaseField, qm31::SecureField},
+        pcs::TreeVec,
     },
-    channel::Channel,
-    fields::{m31::BaseField, qm31::SecureField, secure_column::SECURE_EXTENSION_DEGREE},
-    pcs::TreeVec,
 };
+
+use crate::{
+    executor::{instruction::InstructionElements, state::StateElements},
+    imt::side::{Buy, Sell},
+    VexClaim, VexInteractionClaim,
+};
+
+use bytes::{AndElements, BytesComponent, LessThanU8Elements, RangeCheckU8Elements};
+use insertions::{BuyInsertionComponent, InsertionsEval, SellInsertionComponent};
+use less_than::{
+    LessThanComponent, LessThanElements, StrictLessThanComponent, StrictLessThanElements,
+};
+use poseidon::{PoseidonComponent, PoseidonElements};
+use processor::{ProcessorComponent, ProcessorEval};
 
 pub mod bytes;
 pub mod insertions;
@@ -22,6 +42,8 @@ pub(crate) mod trace_utils;
 
 /// Const trait that defines the number of columns in the trace table
 pub trait TraceSize {
+    /// Number of columns in preprocessed trace table
+    const PREPROCESSED_COLS: usize;
     /// Number of columns in the main trace table
     const MAIN_COLS: usize;
     /// Number of columns in the interaction trace table
@@ -61,9 +83,9 @@ impl<T: TraceSize> Claim<T> {
     #[inline]
     pub fn log_sizes(&self) -> TreeVec<Vec<u32>> {
         TreeVec::new(vec![
-            vec![self.log_size],
+            vec![self.log_size; T::PREPROCESSED_COLS],
             vec![self.log_size; T::MAIN_COLS],
-            vec![self.log_size; SECURE_EXTENSION_DEGREE * T::INTERACTION_COLS],
+            vec![self.log_size; T::INTERACTION_COLS],
         ])
     }
 
@@ -97,6 +119,35 @@ impl<T: TraceSize> InteractionClaim<T> {
     }
 }
 
+/// Interaction Elements for all the components of the system.
+/// Interaction elements are used to combine values that are "used" or "yielded" by the components.
+pub struct VexInteractionElements {
+    pub instruction_elements: InstructionElements,
+    pub state_elements: StateElements,
+    pub poseidon_elements: poseidon::PoseidonElements,
+    pub less_than_elements: less_than::LessThanElements,
+    pub strict_less_than_elements: less_than::StrictLessThanElements,
+    pub less_than_u8_elements: LessThanU8Elements,
+    pub and_elements: bytes::AndElements,
+    pub range_check_u8_elements: bytes::RangeCheckU8Elements,
+}
+
+impl VexInteractionElements {
+    /// Draw all the interaction elements for the components.
+    pub fn draw(channel: &mut impl Channel) -> Self {
+        Self {
+            instruction_elements: InstructionElements::draw(channel),
+            state_elements: StateElements::draw(channel),
+            poseidon_elements: PoseidonElements::draw(channel),
+            less_than_elements: LessThanElements::draw(channel),
+            strict_less_than_elements: StrictLessThanElements::draw(channel),
+            less_than_u8_elements: LessThanU8Elements::draw(channel),
+            and_elements: AndElements::draw(channel),
+            range_check_u8_elements: RangeCheckU8Elements::draw(channel),
+        }
+    }
+}
+
 /// Generate IsReal column.
 /// For any given number of inputs, the size of the column is next power of two.
 /// The First `padding_offset` elements are set to 1; the rest are set to 0.
@@ -121,4 +172,163 @@ pub fn is_real_col(padding_offset: usize) -> BaseColumn {
         is_real.data[vec_row] = PackedBaseField::from_array(res);
     }
     is_real
+}
+
+/// VexComponents is the main struct that holds all the components of the system.
+pub struct VexComponents {
+    processor: ProcessorComponent,
+    buy_insert: BuyInsertionComponent,
+    sell_insert: SellInsertionComponent,
+    poseidon: PoseidonComponent,
+    strict_less_than: StrictLessThanComponent,
+    less_than: LessThanComponent,
+    bytes: BytesComponent,
+}
+
+impl VexComponents {
+    /// Create a new instance of VexComponents.
+    pub fn new(
+        claim: &VexClaim,
+        interaction_elements: &VexInteractionElements,
+        interaction_claim: &VexInteractionClaim,
+    ) -> Self {
+        let tree_span_provider = &mut TraceLocationAllocator::default();
+
+        let bytes = bytes::BytesComponent::new(
+            tree_span_provider,
+            bytes::BytesEval {
+                claim: claim.bytes_claim.clone(),
+                and_elements: interaction_elements.and_elements.clone(),
+                less_than_u8_elements: interaction_elements.less_than_u8_elements.clone(),
+                range_check_u8_elements: interaction_elements.range_check_u8_elements.clone(),
+            },
+            interaction_claim.bytes_interaction_claim.claimed_sum,
+        );
+
+        let poseidon = poseidon::PoseidonComponent::new(
+            tree_span_provider,
+            poseidon::PoseidonEval {
+                claim: claim.poseidon_claim.clone(),
+                poseidon_elements: interaction_elements.poseidon_elements.clone(),
+            },
+            interaction_claim.poseidon_interaction_claim.claimed_sum,
+        );
+
+        let strict_less_than = less_than::StrictLessThanComponent::new(
+            tree_span_provider,
+            less_than::LessThanEval {
+                claim: claim.strict_less_than_claim.clone(),
+                less_than_elements: interaction_elements.less_than_elements.clone(),
+                strict_less_than_elements: interaction_elements.strict_less_than_elements.clone(),
+                less_than_u8_elements: interaction_elements.less_than_u8_elements.clone(),
+            },
+            interaction_claim
+                .strict_less_than_interaction_claim
+                .claimed_sum,
+        );
+
+        let less_than = LessThanComponent::new(
+            tree_span_provider,
+            less_than::LessThanEval {
+                claim: claim.less_than_claim.clone(),
+                less_than_elements: interaction_elements.less_than_elements.clone(),
+                strict_less_than_elements: interaction_elements.strict_less_than_elements.clone(),
+                less_than_u8_elements: interaction_elements.less_than_u8_elements.clone(),
+            },
+            interaction_claim.less_than_interaction_claim.claimed_sum,
+        );
+
+        let processor = ProcessorComponent::new(
+            tree_span_provider,
+            ProcessorEval {
+                claim: claim.processor_claim.clone(),
+                instruction_elements: interaction_elements.instruction_elements.clone(),
+                state_elements: interaction_elements.state_elements.clone(),
+            },
+            interaction_claim.processor_interaction_claim.claimed_sum,
+        );
+
+        let buy_insert = BuyInsertionComponent::new(
+            tree_span_provider,
+            InsertionsEval {
+                claim: claim.buy_insert_claim.clone(),
+                instruction_elements: interaction_elements.instruction_elements.clone(),
+                poseidon_elements: interaction_elements.poseidon_elements.clone(),
+                less_than_elements: interaction_elements.less_than_elements.clone(),
+                strict_less_than_elements: interaction_elements.strict_less_than_elements.clone(),
+                _side: PhantomData::<Buy>,
+            },
+            interaction_claim.buy_insert_interaction_claim.claimed_sum,
+        );
+
+        let sell_insert = SellInsertionComponent::new(
+            tree_span_provider,
+            InsertionsEval {
+                claim: claim.sell_insert_claim.clone(),
+                instruction_elements: interaction_elements.instruction_elements.clone(),
+                poseidon_elements: interaction_elements.poseidon_elements.clone(),
+                less_than_elements: interaction_elements.less_than_elements.clone(),
+                strict_less_than_elements: interaction_elements.strict_less_than_elements.clone(),
+                _side: PhantomData::<Sell>,
+            },
+            interaction_claim.sell_insert_interaction_claim.claimed_sum,
+        );
+
+        Self {
+            processor,
+            strict_less_than,
+            less_than,
+            buy_insert,
+            sell_insert,
+            poseidon,
+            bytes,
+        }
+    }
+
+    /// Returns the ComponentProver of each components whose log sizes are in decreasing order.
+    pub fn provers(&self) -> Vec<&dyn ComponentProver<SimdBackend>> {
+        vec![
+            &self.bytes,
+            &self.poseidon,
+            &self.strict_less_than,
+            &self.less_than,
+            &self.processor,
+            &self.buy_insert,
+            &self.sell_insert,
+        ]
+    }
+
+    /// Returns the Component of each components whose log sizes are in decreasing order.
+    pub fn components(&self) -> Vec<&dyn Component> {
+        self.provers()
+            .into_iter()
+            .map(|component| component as &dyn Component)
+            .collect()
+    }
+}
+
+/// The Components contained in VEX
+#[derive(Clone, Copy)]
+pub enum VexComponent {
+    /// Hiher Level Tree Components
+    InsertBuyOrder,
+    InsertSellOrder,
+    UpdateBuyOrder,
+    UpdateSellOrder,
+    CancelBuyOrder,
+    CancelSellOrder,
+    MatchBuyOrder,
+    MatchSellOrder,
+    PartialMatchBuyOrder,
+    PartialMatchSellOrder,
+
+    /// Sub Operations Components
+    LessThan,
+    Bytes,
+    StrictLessThan,
+    Addition,
+    Poseidon,
+
+    /// Main Processor Component
+    Processor,
 }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -40,6 +40,8 @@ pub mod poseidon;
 pub mod processor;
 pub(crate) mod trace_utils;
 
+pub use trace_utils::is_first;
+
 /// Const trait that defines the number of columns in the trace table
 pub trait TraceSize {
     /// Number of columns in preprocessed trace table

--- a/src/components/poseidon/mod.rs
+++ b/src/components/poseidon/mod.rs
@@ -1,8 +1,8 @@
 use itertools::{chain, Itertools};
 use num_traits::{One, Zero};
-use rayon::iter::{
-    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
-};
+// use rayon::iter::{
+//     IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+// };
 use std::array;
 use stwo_air_utils::trace::component_trace::ComponentTrace;
 use stwo_prover::{
@@ -165,13 +165,8 @@ pub fn trace(
     let mut trace = ComponentTrace::<{ PoseidonColumn::MAIN_COLS - 1 }>::zeroed(log_size);
 
     trace
-        .par_iter_mut()
-        .zip(
-            poseidon_operations
-                .par_iter()
-                .chunks(N_LANES * N_INSTANCES_PER_ROW)
-                .into_par_iter(),
-        )
+        .iter_mut()
+        .zip(poseidon_operations.chunks_exact(N_INSTANCES_PER_ROW * N_LANES))
         .for_each(|(mut row, data)| {
             let mut col_index = 0;
             for rep_i in 0..N_INSTANCES_PER_ROW {
@@ -272,8 +267,13 @@ pub fn interaction_trace(
 pub struct PoseidonColumn;
 
 impl TraceSize for PoseidonColumn {
+    // is_first column
+    const PREPROCESSED_COLS: usize = 1;
+    // initial state + state transitions for each round + final state + is_real
     const MAIN_COLS: usize = N_COLUMNS;
-    const INTERACTION_COLS: usize = N_INSTANCES_PER_ROW * N_ELEMENTS * SECURE_EXTENSION_DEGREE;
+    // initial state + final hash is combined in 1 interaction column for 1 instance
+    // per row => N_INSTANCES_PER_ROW interaction columns
+    const INTERACTION_COLS: usize = N_INSTANCES_PER_ROW * SECURE_EXTENSION_DEGREE;
 }
 
 #[cfg(test)]

--- a/src/components/processor/constraints.rs
+++ b/src/components/processor/constraints.rs
@@ -1,0 +1,124 @@
+use crate::executor::{flatten_single, state::StateElements};
+use num_traits::One;
+use stwo_prover::constraint_framework::{EvalAtRow, FrameworkEval, RelationEntry};
+
+use crate::{
+    components::Claim,
+    executor::instruction::{Instruction, InstructionElements},
+    flatten,
+};
+
+use super::ProcessorColumn;
+
+#[derive(Clone)]
+pub struct ProcessorEval {
+    pub claim: Claim<ProcessorColumn>,
+    pub state_elements: StateElements,
+    pub instruction_elements: InstructionElements,
+}
+
+/// This implementation of the `FrameworkEval` trait for `ProcessorEval` provides methods to evaluate
+/// constraints on Main Trace/Processor component.
+///
+/// # Constaint Evaluation
+///
+/// - `evaluate<E: EvalAtRow>(&self, mut eval: E) -> E`:
+///
+///   The method follows these steps:
+///   1. Retrieve Instruction for the row
+///   2. IsReal must be a boolean. it is true if the operation is from non-padded row.
+///   3. Use the initial state, which was yielded by the previous row.
+///         - the first state is not yielded by any row
+///         - the end state is yielded by the last row and not used by any row
+///         - The sum for this component will be non zero x
+///         - zero = x - initial_state + final_state
+///  4. Use the instruction elements to update the state to the final state.
+///  5. Ensure that the state count is updated correctly.
+///  6. Yield the final state.  
+///  7. Finalize the evaluation by calling `eval.finalize_logup_in_pairs()`.
+///
+impl FrameworkEval for ProcessorEval {
+    fn log_size(&self) -> u32 {
+        self.claim.log_size
+    }
+    fn max_constraint_log_degree_bound(&self) -> u32 {
+        self.claim.log_size + 1
+    }
+    fn evaluate<E: EvalAtRow>(&self, mut eval: E) -> E {
+        let op = Instruction::<E::F>::from_eval(&mut eval);
+
+        // is_real must be a boolean
+        eval.add_constraint(op.is_real.clone() * (op.is_real.clone() - E::F::one()));
+
+        let mult = E::EF::from(op.is_real.clone());
+
+        let initial_state: Vec<E::F> = flatten!(
+            op.initial_state.n.clone(),
+            op.initial_state.buy_root_hash.clone(),
+            op.initial_state.buy_imt_priority.clone(),
+            op.initial_state.sell_root_hash.clone(),
+            op.initial_state.sell_imt_priority.clone()
+        );
+
+        // use the initial state
+        eval.add_to_relation(RelationEntry::new(
+            &self.state_elements,
+            mult.clone(),
+            &initial_state,
+        ));
+
+        let values: Vec<E::F> = flatten!(
+            op.initial_state.n.clone(),
+            op.initial_state.buy_root_hash,
+            op.initial_state.buy_imt_priority,
+            op.initial_state.sell_root_hash,
+            op.initial_state.sell_imt_priority,
+            op.opcode,
+            op.low_merkle_proof,
+            op.low_merkle_path,
+            op.updated_low_merkle_path,
+            op.low_index,
+            op.low_leaf,
+            op.merkle_proof,
+            op.merkle_path,
+            op.updated_merkle_path,
+            op.index,
+            op.leaf,
+            op.final_state.n.clone(),
+            op.final_state.buy_root_hash.clone(),
+            op.final_state.buy_imt_priority.clone(),
+            op.final_state.sell_root_hash.clone(),
+            op.final_state.sell_imt_priority.clone(),
+            op.is_real
+        );
+        // use the instruction elements to update the state to the final state
+        eval.add_to_relation(RelationEntry::new(
+            &self.instruction_elements,
+            mult.clone(),
+            &values,
+        ));
+
+        // ensure that the state count is updated correctly
+        eval.add_constraint(op.final_state.n.clone() - op.initial_state.n.clone() - E::F::one());
+
+        let final_state: Vec<E::F> = flatten!(
+            op.final_state.n,
+            op.final_state.buy_root_hash,
+            op.final_state.buy_imt_priority,
+            op.final_state.sell_root_hash,
+            op.final_state.sell_imt_priority
+        );
+
+        // yield the final state
+        eval.add_to_relation(RelationEntry::new(
+            &self.state_elements,
+            -mult.clone(),
+            &final_state,
+        ));
+
+        // the inital and final state relations are batched in pairs in the first interaction column
+        // the instruction elements are in the second interaction column
+        eval.finalize_logup_batched(&vec![0, 1, 0]);
+        eval
+    }
+}

--- a/src/components/processor/constraints.rs
+++ b/src/components/processor/constraints.rs
@@ -116,9 +116,12 @@ impl FrameworkEval for ProcessorEval {
             &final_state,
         ));
 
+        // Each vector member corresponds to a logup entry, and contains the batch number to which the
+        // entry should be added.
         // the inital and final state relations are batched in pairs in the first interaction column
         // the instruction elements are in the second interaction column
-        eval.finalize_logup_batched(&vec![0, 1, 0]);
+        let batching = vec![0, 1, 0];
+        eval.finalize_logup_batched(&batching);
         eval
     }
 }

--- a/src/components/processor/mod.rs
+++ b/src/components/processor/mod.rs
@@ -1,4 +1,6 @@
-use stwo_prover::core::fields::secure_column::SECURE_EXTENSION_DEGREE;
+use stwo_prover::{
+    constraint_framework::FrameworkComponent, core::fields::secure_column::SECURE_EXTENSION_DEGREE,
+};
 
 use crate::executor::instruction::N_INSTRUCTION_FELTS;
 
@@ -7,7 +9,10 @@ use super::TraceSize;
 mod constraints;
 mod trace;
 
+pub use constraints::ProcessorEval;
 pub use trace::{interaction_trace, preprocessed_trace, trace};
+
+pub type ProcessorComponent = FrameworkComponent<ProcessorEval>;
 
 /// Processor Column
 /// Each row of the trace is a Instruction field elements arranged as per the `InstructionColumn`
@@ -16,6 +21,7 @@ pub use trace::{interaction_trace, preprocessed_trace, trace};
 pub struct ProcessorColumn;
 
 impl TraceSize for ProcessorColumn {
+    const PREPROCESSED_COLS: usize = 1;
     const MAIN_COLS: usize = N_INSTRUCTION_FELTS;
     /// 1st Column:"use initial state" and "yield final state" logups are batched
     /// 2nd Column: "use instruction elements"

--- a/src/components/processor/mod.rs
+++ b/src/components/processor/mod.rs
@@ -1,0 +1,104 @@
+use stwo_prover::core::fields::secure_column::SECURE_EXTENSION_DEGREE;
+
+use crate::executor::instruction::N_INSTRUCTION_FELTS;
+
+use super::TraceSize;
+
+mod constraints;
+mod trace;
+
+pub use trace::{interaction_trace, preprocessed_trace, trace};
+
+/// Processor Column
+/// Each row of the trace is a Instruction field elements arranged as per the `InstructionColumn`
+/// The last field is a flag to indicate if the row is real or padded
+#[derive(Debug, Clone)]
+pub struct ProcessorColumn;
+
+impl TraceSize for ProcessorColumn {
+    const MAIN_COLS: usize = N_INSTRUCTION_FELTS;
+    /// 1st Column:"use initial state" and "yield final state" logups are batched
+    /// 2nd Column: "use instruction elements"
+    const INTERACTION_COLS: usize = 2 * SECURE_EXTENSION_DEGREE;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use constraints::ProcessorEval;
+    use rand::Rng;
+    use stwo_prover::{
+        constraint_framework::{assert_constraints, FrameworkEval},
+        core::{channel::Blake2sChannel, pcs::TreeVec, poly::circle::CanonicCoset},
+    };
+    use trace::{interaction_trace, preprocessed_trace, trace};
+    use tracing::{span, Level};
+
+    use crate::{
+        executor::{
+            instruction::InstructionElements, order_book::OrderBook, record::ExecutionTrace,
+            state::StateElements,
+        },
+        imt::order::Order,
+    };
+
+    use super::*;
+
+    #[test_log::test]
+    fn test_processor_table() {
+        // Execution Record
+        let span = span!(Level::INFO, "Generating Execution Record").entered();
+        let record = Rc::new(RefCell::new(ExecutionTrace::new()));
+        let mut order_book = OrderBook::new(Rc::clone(&record));
+        let mut rng = rand::thread_rng();
+        let mut time = 1;
+        let n = 16;
+        for _ in 0..n {
+            let time_inc = rng.gen_range(1..=16);
+            time += time_inc;
+            let buy_order = Order::new(rng.gen_range(1..=50), rng.gen_range(51..=100), time);
+            let sell_order = Order::new(rng.gen_range(101..=150), rng.gen_range(151..=200), time);
+            order_book.place_buy_order(buy_order).unwrap();
+            order_book.place_sell_order(sell_order).unwrap();
+        }
+
+        let execution_trace = std::mem::replace(&mut *record.borrow_mut(), ExecutionTrace::new());
+        span.exit();
+
+        // Fiat Shamir Channel
+        let mut channel = Blake2sChannel::default();
+
+        // Relation Elements
+        let state_elements = StateElements::draw(&mut channel);
+        let instruction_elements = InstructionElements::draw(&mut channel);
+
+        let log_size = (execution_trace.instructions.len() - 1).ilog2() + 1;
+        let span = span!(Level::INFO, "Trace Generation", log_size).entered();
+        let constant_trace = preprocessed_trace(log_size);
+        let (trace, claim) = trace(execution_trace.instructions);
+        let (interaction_trace, interaction_claim) =
+            interaction_trace(&trace, &state_elements, &instruction_elements);
+        span.exit();
+
+        let _span = span!(Level::INFO, "Evaluating Constraints", log_size).entered();
+        let trace = TreeVec::new(vec![constant_trace, trace, interaction_trace]);
+        let trace_polys = TreeVec::<Vec<_>>::map_cols(trace, |c| c.interpolate());
+
+        let component: ProcessorEval = ProcessorEval {
+            state_elements: state_elements.clone(),
+            instruction_elements: instruction_elements.clone(),
+            claim,
+        };
+
+        // panics if the constraints are not satisfied
+        assert_constraints(
+            &trace_polys,
+            CanonicCoset::new(log_size),
+            |eval| {
+                component.evaluate(eval);
+            },
+            interaction_claim.claimed_sum,
+        );
+    }
+}

--- a/src/components/processor/trace.rs
+++ b/src/components/processor/trace.rs
@@ -1,0 +1,123 @@
+use crate::{
+    components::{
+        trace_utils::{add_interaction_col, add_interaction_col_batched},
+        Claim, InteractionClaim, TraceSize,
+    },
+    executor::{
+        instruction::{InstructionColumn, InstructionElements},
+        record::Instructions,
+        state::{StateElements, N_STATE_FELTS},
+    },
+};
+use itertools::Itertools;
+use num_traits::{One, Zero};
+use rayon::{
+    iter::{IndexedParallelIterator, ParallelIterator},
+    slice::ParallelSlice,
+};
+use std::array;
+use stwo_air_utils::trace::component_trace::ComponentTrace;
+use stwo_prover::{
+    constraint_framework::{logup::LogupTraceGenerator, preprocessed_columns::IsFirst},
+    core::{
+        backend::simd::{
+            m31::{PackedBaseField, N_LANES},
+            qm31::PackedSecureField,
+            SimdBackend,
+        },
+        fields::m31::BaseField,
+        poly::{circle::CircleEvaluation, BitReversedOrder},
+        ColumnVec,
+    },
+};
+use tracing::{debug, span, Level};
+
+use super::ProcessorColumn;
+
+/// Preprocessed Trace for Processor Trace, each row consisting of a single field element
+/// First row is M31(1), rest are M31(0)
+pub fn preprocessed_trace(
+    log_size: u32,
+) -> ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>> {
+    vec![IsFirst::new(log_size).gen_column_simd()]
+}
+
+/// Trace for the Processor Component
+/// The Trace must consist of all the instructions on both IMT's
+/// each row consisting of a [BaseField; InstructionColumn::MAIN_COLS]
+pub fn trace(
+    mut instructions: Instructions<BaseField>,
+) -> (
+    ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>,
+    Claim<ProcessorColumn>,
+) {
+    let _span = span!(Level::INFO, "Processor: Main Trace").entered();
+    // calculate shape of the trace table
+    let log_size = (instructions.len() - 1).ilog2() + 1;
+    debug!("Log Size: {}", log_size);
+    // pad instructions to a power of 2
+    let mut dummy = instructions[0];
+    dummy[InstructionColumn::IS_REAL] = BaseField::zero();
+    for _ in 0..(1 << log_size) - instructions.len() {
+        instructions.push(instructions[0]);
+    }
+    let mut trace = ComponentTrace::<{ ProcessorColumn::MAIN_COLS }>::zeroed(log_size);
+    trace
+        .par_iter_mut()
+        .zip(instructions.par_chunks_exact(N_LANES))
+        .for_each(|(row, data)| {
+            for (i, cell) in row.into_iter().enumerate() {
+                let column_chunk = core::array::from_fn(|j| data[j][i]); // Extracts the i-th column from 16 rows
+                *cell = PackedBaseField::from_array(column_chunk);
+            }
+        });
+    (trace.to_evals().to_vec(), Claim::new(log_size))
+}
+
+/// Processor Interaction Trace
+pub fn interaction_trace(
+    trace: &ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>,
+    state_elements: &StateElements,
+    instruction_elements: &InstructionElements,
+) -> (
+    ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>>,
+    InteractionClaim<ProcessorColumn>,
+) {
+    let _span = span!(Level::INFO, "Processor: Interaction Trace").entered();
+    let log_size = trace[0].domain.log_size();
+    let mut logup_gen = LogupTraceGenerator::new(log_size);
+
+    // Extract the columns from the trace used for the interaction trace
+    let initial_state: [&Vec<PackedBaseField>; N_STATE_FELTS] =
+        array::from_fn(|i| &trace[InstructionColumn::INITIAL_STATE + i].data);
+    let is_real = &trace[InstructionColumn::IS_REAL].data;
+    let final_state: [&Vec<PackedBaseField>; N_STATE_FELTS] =
+        array::from_fn(|i| &trace[InstructionColumn::FINAL_STATE + i].data);
+    let instruction = trace.iter().map(|c| &c.data).collect_vec();
+
+    // 1st interaction column
+    // batched interaction columns for initial and final state
+    add_interaction_col_batched(
+        &mut logup_gen,
+        &initial_state,
+        &final_state,
+        is_real,
+        log_size,
+        state_elements,
+        PackedSecureField::one(),
+        -PackedSecureField::one(),
+    );
+
+    // 2nd interaction column
+    // interaction column for instruction elements
+    add_interaction_col(
+        &mut logup_gen,
+        &instruction,
+        is_real,
+        log_size,
+        instruction_elements,
+        PackedSecureField::one(),
+    );
+    let (trace, claimed_sum) = logup_gen.finalize_last();
+    (trace, InteractionClaim::new(claimed_sum))
+}

--- a/src/components/processor/trace.rs
+++ b/src/components/processor/trace.rs
@@ -59,7 +59,7 @@ pub fn trace(
     let mut dummy = instructions[0];
     dummy[InstructionColumn::IS_REAL] = BaseField::zero();
     for _ in 0..(1 << log_size) - instructions.len() {
-        instructions.push(instructions[0]);
+        instructions.push(dummy);
     }
     let mut trace = ComponentTrace::<{ ProcessorColumn::MAIN_COLS }>::zeroed(log_size);
     trace

--- a/src/components/trace_utils.rs
+++ b/src/components/trace_utils.rs
@@ -1,15 +1,26 @@
 use itertools::{chain, Itertools};
 use num_traits::{One, Zero};
 use stwo_prover::{
-    constraint_framework::{logup::LogupTraceGenerator, Relation},
+    constraint_framework::{logup::LogupTraceGenerator, preprocessed_columns::IsFirst, Relation},
     core::{
         backend::simd::{
             m31::{PackedBaseField, LOG_N_LANES, N_LANES},
             qm31::PackedSecureField,
+            SimdBackend,
         },
         fields::m31::BaseField,
+        poly::{circle::CircleEvaluation, BitReversedOrder},
+        ColumnVec,
     },
 };
+
+/// generate preprocessed column for is_first
+/// is_first is a column that is 1 for the first row and 0 for the rest
+pub fn is_first(
+    log_size: u32,
+) -> ColumnVec<CircleEvaluation<SimdBackend, BaseField, BitReversedOrder>> {
+    vec![IsFirst::new(log_size).gen_column_simd()]
+}
 
 /// add_interaction_col adds an interaction column to the logup generator for the given lookup elements in the given columns
 pub fn add_interaction_col<X: Relation<PackedBaseField, PackedSecureField>>(

--- a/src/components/trace_utils.rs
+++ b/src/components/trace_utils.rs
@@ -64,6 +64,7 @@ pub fn add_merkle_interaction_col<X: Relation<PackedBaseField, PackedSecureField
     is_real: &Vec<PackedBaseField>,
     log_size: u32,
     lookup_elements: &X,
+    mult: PackedSecureField,
 ) {
     let mut col_gen = logup_gen.new_col();
     for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {
@@ -98,7 +99,7 @@ pub fn add_merkle_interaction_col<X: Relation<PackedBaseField, PackedSecureField
         left.extend(right);
         left.extend(hash);
         let p1 = lookup_elements.combine(&left);
-        col_gen.write_frac(vec_row, PackedSecureField::one() * is_real[vec_row], p1);
+        col_gen.write_frac(vec_row, mult * is_real[vec_row], p1);
     }
     col_gen.finalize_col();
 }

--- a/src/components/trace_utils.rs
+++ b/src/components/trace_utils.rs
@@ -1,0 +1,130 @@
+use itertools::{chain, Itertools};
+use num_traits::{One, Zero};
+use stwo_prover::{
+    constraint_framework::{logup::LogupTraceGenerator, Relation},
+    core::{
+        backend::simd::{
+            m31::{PackedBaseField, LOG_N_LANES, N_LANES},
+            qm31::PackedSecureField,
+        },
+        fields::m31::BaseField,
+    },
+};
+
+/// add_interaction_col adds an interaction column to the logup generator for the given lookup elements in the given columns
+pub fn add_interaction_col<X: Relation<PackedBaseField, PackedSecureField>>(
+    logup_gen: &mut LogupTraceGenerator,
+    cols: &[&Vec<PackedBaseField>],
+    is_real: &Vec<PackedBaseField>,
+    log_size: u32,
+    lookup_elements: &X,
+    mult: PackedSecureField,
+) {
+    let mut col_gen = logup_gen.new_col();
+    for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {
+        let values1: Vec<PackedBaseField> = cols.iter().map(|col| col[vec_row]).collect();
+        let p1 = lookup_elements.combine(&values1);
+        col_gen.write_frac(vec_row, mult * is_real[vec_row], p1);
+    }
+    col_gen.finalize_col();
+}
+
+/// add_less_than_interaction_col adds an interaction column to the logup generator for the given a and b columns
+/// for strict less than comparison lookup elements must be StrictLessThanElements
+/// for less than comparison lookup elements must be LessThanElements
+pub fn add_less_than_interaction_col<R: Relation<PackedBaseField, PackedSecureField>>(
+    logup_gen: &mut LogupTraceGenerator,
+    col_a: &[&Vec<PackedBaseField>],
+    col_b: &[&Vec<PackedBaseField>],
+    is_real: &Vec<PackedBaseField>,
+    log_size: u32,
+    lookup_elements: &R,
+) {
+    let mut col_gen = logup_gen.new_col();
+    for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {
+        let a: Vec<PackedBaseField> = col_a.iter().map(|col| col[vec_row]).collect();
+        let b: Vec<PackedBaseField> = col_b.iter().map(|col| col[vec_row]).collect();
+        let c = PackedBaseField::one();
+        let values = chain!(a.into_iter(), b.into_iter(), std::iter::once(c)).collect_vec();
+        let p1 = lookup_elements.combine(&values);
+        col_gen.write_frac(vec_row, PackedSecureField::one() * is_real[vec_row], p1);
+    }
+    col_gen.finalize_col();
+}
+
+/// add_merkle_interaction_col adds an interaction column to the logup generator for the current and sibling columns
+/// the left and right values are determined by the index column
+/// [left, right, hash] -> lookup_elements
+pub fn add_merkle_interaction_col<X: Relation<PackedBaseField, PackedSecureField>>(
+    logup_gen: &mut LogupTraceGenerator,
+    curr: &[&Vec<PackedBaseField>],
+    sibling: &[&Vec<PackedBaseField>],
+    hash: &[&Vec<PackedBaseField>],
+    index: &Vec<PackedBaseField>,
+    is_real: &Vec<PackedBaseField>,
+    log_size: u32,
+    lookup_elements: &X,
+) {
+    let mut col_gen = logup_gen.new_col();
+    for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {
+        let cur: Vec<PackedBaseField> = curr.iter().map(|col| col[vec_row]).collect();
+        let sib: Vec<PackedBaseField> = sibling.iter().map(|col| col[vec_row]).collect();
+        let hash: Vec<PackedBaseField> = hash.iter().map(|col| col[vec_row]).collect();
+        let index: PackedBaseField = index[vec_row];
+        let (mut left, right): (Vec<PackedBaseField>, Vec<PackedBaseField>) = cur
+            .into_iter()
+            .zip(sib.into_iter())
+            .map(|(a, b)| {
+                let a = a.to_array();
+                let b = b.to_array();
+                let index = index.to_array();
+                let mut left = [BaseField::zero(); N_LANES];
+                let mut right = [BaseField::zero(); N_LANES];
+                for i in 0..N_LANES {
+                    if index[i] == BaseField::zero() {
+                        left[i] = a[i];
+                        right[i] = b[i];
+                    } else {
+                        left[i] = b[i];
+                        right[i] = a[i];
+                    }
+                }
+                (
+                    PackedBaseField::from_array(left),
+                    PackedBaseField::from_array(right),
+                )
+            })
+            .unzip();
+        left.extend(right);
+        left.extend(hash);
+        let p1 = lookup_elements.combine(&left);
+        col_gen.write_frac(vec_row, PackedSecureField::one() * is_real[vec_row], p1);
+    }
+    col_gen.finalize_col();
+}
+
+/// add_interaction_col adds an interaction column to the logup generator for the given lookup elements in the given columns
+pub fn add_interaction_col_batched<X: Relation<PackedBaseField, PackedSecureField>>(
+    logup_gen: &mut LogupTraceGenerator,
+    cols1: &[&Vec<PackedBaseField>],
+    cols2: &[&Vec<PackedBaseField>],
+    is_real: &Vec<PackedBaseField>,
+    log_size: u32,
+    lookup_elements: &X,
+    mult1: PackedSecureField,
+    mult2: PackedSecureField,
+) {
+    let mut col_gen = logup_gen.new_col();
+    for vec_row in 0..(1 << (log_size - LOG_N_LANES)) {
+        let values1: Vec<PackedBaseField> = cols1.iter().map(|col| col[vec_row]).collect();
+        let values2: Vec<PackedBaseField> = cols2.iter().map(|col| col[vec_row]).collect();
+        let p1 = lookup_elements.combine(&values1);
+        let p2 = lookup_elements.combine(&values2);
+        col_gen.write_frac(
+            vec_row,
+            (p2 * mult1 + p1 * mult2) * is_real[vec_row],
+            p1 * p2,
+        );
+    }
+    col_gen.finalize_col();
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use stwo_prover::core::prover::VerificationError;
+
 use crate::imt::error::IMTError;
 use std::fmt;
 
@@ -6,6 +8,8 @@ pub enum GenericError {
     IMT(IMTError),
     InvalidSliceLength(usize, usize),
     InvalidUint8,
+    InvalidLogupSum,
+    Stark(VerificationError),
 }
 
 impl fmt::Display for GenericError {
@@ -21,6 +25,12 @@ impl fmt::Display for GenericError {
                     "Each element in the u64 'M31 limbs representation' must be less than 256"
                 )
             }
+            GenericError::InvalidLogupSum => {
+                write!(f, "Total Lookup sum must be zero")
+            }
+            GenericError::Stark(err) => {
+                write!(f, "Stark error: {}", err)
+            }
         }
     }
 }
@@ -29,6 +39,34 @@ impl std::error::Error for GenericError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             GenericError::IMT(err) => Some(err),
+            _ => Some(self),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum VexVerificationError {
+    InvalidLogupSum,
+    Stark(VerificationError),
+}
+
+impl fmt::Display for VexVerificationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VexVerificationError::InvalidLogupSum => {
+                write!(f, "Total Lookup sum must be zero")
+            }
+            VexVerificationError::Stark(err) => {
+                write!(f, "Stark error: {}", err)
+            }
+        }
+    }
+}
+
+impl std::error::Error for VexVerificationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            VexVerificationError::Stark(err) => Some(err),
             _ => Some(self),
         }
     }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -19,7 +19,15 @@ macro_rules! flatten {
             flatten_single(&mut result, $x);
         )*
 
-        result.try_into().unwrap()
+        // Capture the length before moving `result`
+        let len = result.len();
+        match result.try_into() {
+            Ok(arr) => arr,
+            Err(e) => panic!(
+                "Failed to flatten array: vector size {} doesn't match the expected array size. Error: {:?}",
+                len, e
+            ),
+        }
     }};
 }
 

--- a/src/executor/order_book.rs
+++ b/src/executor/order_book.rs
@@ -47,6 +47,7 @@ impl OrderBook {
             sell_imt.root(),
             PriceTime::<BaseField, Sell>::last().to_felts(),
         );
+        trace.borrow_mut().initial_state = state.to_felts();
         OrderBook {
             buy_imt,
             sell_imt,
@@ -97,6 +98,10 @@ impl OrderBook {
         self.trace.borrow_mut().add_instruction(instruction_felts);
         self.match_buy(order)?;
         Ok(())
+    }
+
+    pub fn state(&self) -> State<BaseField> {
+        self.state
     }
 
     /// Place a sell order in the order book

--- a/src/executor/order_book.rs
+++ b/src/executor/order_book.rs
@@ -65,7 +65,7 @@ impl OrderBook {
         }
         let initial_state = self.state.clone();
         let proof = self.buy_imt.insert(order)?;
-        assert_eq!(initial_state.buy_root_hash, proof.initial_root);
+        debug_assert_eq!(initial_state.buy_root_hash, proof.initial_root);
         let mut final_state = initial_state.clone();
         final_state.n += BaseField::one();
         final_state.buy_root_hash = self.buy_imt.root();
@@ -113,7 +113,7 @@ impl OrderBook {
         }
         let initial_state = self.state.clone();
         let proof = self.sell_imt.insert(order)?;
-        assert_eq!(initial_state.sell_root_hash, proof.initial_root);
+        debug_assert_eq!(initial_state.sell_root_hash, proof.initial_root);
         let mut final_state = initial_state.clone();
         final_state.n += BaseField::one();
         final_state.sell_root_hash = self.sell_imt.root();

--- a/src/executor/record.rs
+++ b/src/executor/record.rs
@@ -235,8 +235,8 @@ impl ExecutionTrace<BaseField> {
         log_size
     }
 
-    /// Returns the log size for a given Opcode
-    pub fn log_size_for_component(&self, component: VexComponent) -> u32 {
+    /// Returns the log size for a given Component
+    pub fn log_size(&self, component: VexComponent) -> u32 {
         let len = match component {
             VexComponent::InsertBuyOrder => self.buy_insert_order.len(),
             VexComponent::CancelBuyOrder => self.buy_delete_order.len(),

--- a/src/executor/record.rs
+++ b/src/executor/record.rs
@@ -1,17 +1,20 @@
-use std::array;
-
-use super::instruction::{InstructionColumn, Opcode, N_INSTRUCTION_FELTS};
+use super::{
+    instruction::{InstructionColumn, Opcode, N_INSTRUCTION_FELTS},
+    state::N_STATE_FELTS,
+};
 use crate::{
     components::{
         bytes::ByteOperations,
         less_than::{LessThanColumn, LessThanOperations},
-        poseidon::PoseidonOperations,
+        poseidon::{PoseidonOperations, N_INSTANCES_PER_ROW},
+        VexComponent,
     },
-    imt::{error::IMTError, LeafFelts},
+    imt::{error::IMTError, LeafFelts, N_U64_FELTS},
     types::N_U64_LIMBS,
 };
-use itertools::{chain, izip, Itertools};
+use itertools::{chain, izip, max, Itertools};
 use num_traits::{One, Zero};
+use std::array;
 use stwo_prover::core::{
     backend::{simd::column::BaseColumn, Column},
     fields::m31::BaseField,
@@ -78,6 +81,10 @@ pub struct ExecutionTrace<F> {
     pub poseidon_operations: PoseidonOperations,
     /// Uint8 Operations
     pub byte_operations: ByteOperations,
+    /// Initial State of the Execution Trace
+    pub initial_state: [F; N_STATE_FELTS],
+    /// Final State
+    pub final_state: [F; N_STATE_FELTS],
 }
 
 impl Default for ExecutionTrace<BaseField> {
@@ -106,7 +113,9 @@ impl ExecutionTrace<BaseField> {
             strict_less_than_operations: Vec::new(),
             comparison_operations: Vec::new(),
             poseidon_operations: Vec::new(),
-            byte_operations: array::from_fn(|_| unsafe { BaseColumn::uninitialized(1 << 16) }),
+            byte_operations: array::from_fn(|_| BaseColumn::zeros(1 << 16)),
+            initial_state: array::from_fn(|_| BaseField::zero()),
+            final_state: array::from_fn(|_| BaseField::zero()),
         }
     }
 
@@ -198,6 +207,55 @@ impl ExecutionTrace<BaseField> {
         let offset = (a << 8) + b;
         self.byte_operations[2].as_mut_slice()[offset as usize].0 += 1;
         Ok(())
+    }
+
+    /// Max Log Size for the Execution Trace
+    pub fn max_log_size(&self) -> u32 {
+        let n = max([
+            self.buy_insert_order.len(),
+            self.buy_delete_order.len(),
+            self.buy_modify_order.len(),
+            self.buy_order_match.len(),
+            self.buy_order_partially_match.len(),
+            self.sell_insert_order.len(),
+            self.sell_delete_order.len(),
+            self.sell_modify_order.len(),
+            self.sell_order_match.len(),
+            self.sell_order_partially_match.len(),
+            self.instructions.len(),
+            self.add_operations.len(),
+            self.less_than_operations.len(),
+            self.strict_less_than_operations.len(),
+            self.comparison_operations.len(),
+            self.poseidon_operations.len() / N_INSTANCES_PER_ROW,
+            1 << 2 * N_U64_FELTS, // 2^8 * 2^8 combinations
+        ])
+        .unwrap();
+        let log_size = (n - 1).ilog2() + 1;
+        log_size
+    }
+
+    /// Returns the log size for a given Opcode
+    pub fn log_size_for_component(&self, component: VexComponent) -> u32 {
+        let len = match component {
+            VexComponent::InsertBuyOrder => self.buy_insert_order.len(),
+            VexComponent::CancelBuyOrder => self.buy_delete_order.len(),
+            VexComponent::UpdateBuyOrder => self.buy_modify_order.len(),
+            VexComponent::MatchBuyOrder => self.buy_order_match.len(),
+            VexComponent::PartialMatchBuyOrder => self.buy_order_partially_match.len(),
+            VexComponent::InsertSellOrder => self.sell_insert_order.len(),
+            VexComponent::CancelSellOrder => self.sell_delete_order.len(),
+            VexComponent::UpdateSellOrder => self.sell_modify_order.len(),
+            VexComponent::MatchSellOrder => self.sell_order_match.len(),
+            VexComponent::PartialMatchSellOrder => self.sell_order_partially_match.len(),
+            VexComponent::Processor => self.instructions.len(),
+            VexComponent::Addition => self.add_operations.len(),
+            VexComponent::LessThan => self.less_than_operations.len(),
+            VexComponent::StrictLessThan => self.strict_less_than_operations.len(),
+            VexComponent::Poseidon => self.poseidon_operations.len() / N_INSTANCES_PER_ROW,
+            VexComponent::Bytes => 1 << N_U64_FELTS, // 2^8 * 2^8 combinations
+        };
+        (len.max(1) - 1).ilog2() + 1
     }
 
     /// Adds a Less Than Event by recording the corresponding Trace Row

--- a/src/executor/record.rs
+++ b/src/executor/record.rs
@@ -251,7 +251,9 @@ impl ExecutionTrace<BaseField> {
     /// Adds an And U8 Event by recording the corresponding Trace Row
     /// Returns an error if a or b is greater than 255
     pub fn add_and_u8_event(&mut self, a: u32, b: u32) -> Result<(), IMTError> {
-        assert!(a < 256 && b < 256, "Invalid U8 Pair");
+        if (a >= 256) || (b >= 256) {
+            return Err(IMTError::InvalidU8Pair(a, b));
+        }
         let offset = (a << 8) + b;
         self.byte_operations[0].as_mut_slice()[offset as usize].0 += 1;
         Ok(())
@@ -260,7 +262,9 @@ impl ExecutionTrace<BaseField> {
     /// Adds a Less Than U8 Event by recording the corresponding Trace Row
     /// Returns an error if a or b is greater than 255
     pub fn add_less_than_u8_event(&mut self, a: u32, b: u32) -> Result<(), IMTError> {
-        assert!(a < 256 && b < 256, "Invalid U8 Pair");
+        if a >= 256 || b >= 256 {
+            return Err(IMTError::InvalidU8Pair(a, b));
+        }
         let offset = (a << 8) + b;
         self.byte_operations[1].as_mut_slice()[offset as usize].0 += 1;
         Ok(())

--- a/src/executor/record.rs
+++ b/src/executor/record.rs
@@ -1,6 +1,6 @@
 use super::{
     instruction::{InstructionColumn, Opcode, N_INSTRUCTION_FELTS},
-    state::N_STATE_FELTS,
+    state::StateFelts,
 };
 use crate::{
     components::{
@@ -82,9 +82,9 @@ pub struct ExecutionTrace<F> {
     /// Uint8 Operations
     pub byte_operations: ByteOperations,
     /// Initial State of the Execution Trace
-    pub initial_state: [F; N_STATE_FELTS],
+    pub initial_state: StateFelts<F>,
     /// Final State
-    pub final_state: [F; N_STATE_FELTS],
+    pub final_state: StateFelts<F>,
 }
 
 impl Default for ExecutionTrace<BaseField> {

--- a/src/executor/state.rs
+++ b/src/executor/state.rs
@@ -1,8 +1,10 @@
-use std::array;
+use std::{array, fmt::Debug};
 
 use stwo_prover::{constraint_framework::EvalAtRow, relation};
 
 use crate::{
+    executor::flatten_single,
+    flatten,
     hash::N_HASH,
     imt::{Hash, PriceTimeFelts, N_U64_FELTS},
 };
@@ -14,7 +16,7 @@ pub const N_STATE_FELTS: usize = 1 // n
     + 2 * N_U64_FELTS; // sell_imt_priority
 
 /// State conists of root hashes and priority orders for Buy and Sell IMTs
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct State<F> {
     /// ith state
     pub n: F,
@@ -65,5 +67,17 @@ impl<F> State<F> {
             sell_root_hash,
             sell_imt_priority,
         }
+    }
+}
+
+impl<F: Clone + Debug + Copy> State<F> {
+    pub fn to_felts(&self) -> [F; N_STATE_FELTS] {
+        flatten!(
+            self.n,
+            self.buy_root_hash,
+            self.buy_imt_priority,
+            self.sell_root_hash,
+            self.sell_imt_priority
+        )
     }
 }

--- a/src/executor/state.rs
+++ b/src/executor/state.rs
@@ -9,6 +9,8 @@ use crate::{
     imt::{Hash, PriceTimeFelts, N_U64_FELTS},
 };
 
+pub type StateFelts<F> = [F; N_STATE_FELTS];
+
 pub const N_STATE_FELTS: usize = 1 // n
     + N_HASH // buy_root_hash
     + 2 * N_U64_FELTS // buy_imt_priority

--- a/src/executor/state.rs
+++ b/src/executor/state.rs
@@ -1,6 +1,6 @@
 use std::array;
 
-use stwo_prover::constraint_framework::EvalAtRow;
+use stwo_prover::{constraint_framework::EvalAtRow, relation};
 
 use crate::{
     hash::N_HASH,
@@ -27,6 +27,11 @@ pub struct State<F> {
     /// the order which should be matched first in the Sell IMT
     pub sell_imt_priority: PriceTimeFelts<F>,
 }
+
+// StateElements are used and yielded in the processor component
+// At each row, the processor uses the StateElements yielded by the previous row
+// the number of elements used/yielded is equal to the number of columns in the State
+relation!(StateElements, N_STATE_FELTS);
 
 impl<F> State<F> {
     /// Creates a new State.

--- a/src/imt/error.rs
+++ b/src/imt/error.rs
@@ -10,7 +10,7 @@ pub enum IMTError {
     OperationFailed(String),
     InsufficientVolumeToFill(u64, u64),
     InvalidU8Pair(u32, u32),
-    InvalidOrder,
+    InvalidOrder,    
 }
 
 impl fmt::Display for IMTError {

--- a/src/imt/mod.rs
+++ b/src/imt/mod.rs
@@ -496,10 +496,12 @@ impl<S: OrderSide> IndexedMerkleTree<S> {
             let sibling_index = if index % 2 == 0 { index + 1 } else { index - 1 };
             *sibling = if sibling_index < self.raw[i].len() {
                 self.raw[i][sibling_index]
-            } else if index % 2 == 0 {
-                Self::get_empty_hash(i)
             } else {
-                panic!("Unexpected condition: index is odd and sibling index is out of bounds");
+                debug_assert!(
+                    index % 2 != 0,
+                    "Unreachable: index is even and sibling index is out of bounds"
+                );
+                Self::get_empty_hash(i)
             };
             if index % 2 == 0 {
                 trace.add_merkle_hash_event(path[i], *sibling);

--- a/src/imt/side.rs
+++ b/src/imt/side.rs
@@ -2,7 +2,10 @@ use std::fmt::Debug;
 
 use stwo_prover::core::fields::m31::BaseField;
 
-use crate::{executor::instruction::IMTOperation, types::Price};
+use crate::{
+    executor::instruction::{IMTOperation, Opcode},
+    types::Price,
+};
 
 /// Type markers for Buy and Sell sides
 #[derive(Debug, Clone, Copy)]
@@ -46,11 +49,11 @@ impl OrderSide for Buy {
     }
     fn op_code(op: IMTOperation) -> BaseField {
         match op {
-            IMTOperation::Insertion => BaseField::from_u32_unchecked(0),
-            IMTOperation::Deletion => BaseField::from_u32_unchecked(2),
-            IMTOperation::Update => BaseField::from_u32_unchecked(4),
-            IMTOperation::Match => BaseField::from_u32_unchecked(6),
-            IMTOperation::PartialMatch => BaseField::from_u32_unchecked(8),
+            IMTOperation::Insertion => Opcode::InsertBuyOrder.to_field(),
+            IMTOperation::Update => Opcode::UpdateBuyOrder.to_field(),
+            IMTOperation::Deletion => Opcode::CancelBuyOrder.to_field(),
+            IMTOperation::Match => Opcode::MatchBuyOrder.to_field(),
+            IMTOperation::PartialMatch => Opcode::PartialMatchBuyOrder.to_field(),
         }
     }
 }
@@ -64,11 +67,11 @@ impl OrderSide for Sell {
     }
     fn op_code(op: IMTOperation) -> BaseField {
         match op {
-            IMTOperation::Insertion => BaseField::from_u32_unchecked(1),
-            IMTOperation::Deletion => BaseField::from_u32_unchecked(3),
-            IMTOperation::Update => BaseField::from_u32_unchecked(5),
-            IMTOperation::Match => BaseField::from_u32_unchecked(7),
-            IMTOperation::PartialMatch => BaseField::from_u32_unchecked(9),
+            IMTOperation::Insertion => Opcode::InsertSellOrder.to_field(),
+            IMTOperation::Update => Opcode::UpdateSellOrder.to_field(),
+            IMTOperation::Deletion => Opcode::CancelSellOrder.to_field(),
+            IMTOperation::Match => Opcode::MatchSellOrder.to_field(),
+            IMTOperation::PartialMatch => Opcode::PartialMatchSellOrder.to_field(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,32 +1,172 @@
 #![feature(btree_cursors, portable_simd, iter_array_chunks)]
+#![feature(trait_upcasting)]
 
-use components::{bytes::BytesPreProcessedColumn, Claim, InteractionClaim};
-use stwo_prover::core::{prover::StarkProof, vcs::ops::MerkleHasher};
+use crate::executor::state::StateFelts;
+use components::{
+    bytes::BytesPreProcessedColumn, insertions::InsertionsColumn, less_than::LessThanColumn,
+    poseidon::PoseidonColumn, processor::ProcessorColumn, Claim, InteractionClaim,
+};
+use num_traits::Zero;
+use stwo_prover::core::{
+    channel::Channel,
+    fields::{m31::BaseField, qm31::SecureField},
+    pcs::TreeVec,
+    prover::StarkProof,
+    vcs::ops::MerkleHasher,
+};
+
 pub mod components;
 pub mod constants;
 pub mod error;
 pub mod executor;
 pub mod hash;
 pub mod imt;
+pub mod prover;
 pub mod types;
 
+#[derive(Debug)]
 pub struct VexProof<H: MerkleHasher> {
     pub stark_proof: StarkProof<H>,
     pub claim: VexClaim,
     pub interaction_claim: VexInteractionClaim,
 }
 
+/// Claim for the Vex Prover
+/// Claim containts public inputs, initial state, final state and all the components
+/// and LogSizes for each component
 pub struct VexClaim {
-    /// The public inputs to the circuit.
-    pub inputs: Vec<u8>,
-    /// public outputs contains the root hash of the IMT
-    pub outputs: Vec<u8>,
+    /// The Initial State of the Matching Engine
+    pub initial_state: StateFelts<BaseField>,
+    /// The Final State of the Matching Engine
+    pub final_state: StateFelts<BaseField>,
+    /// processor claim
+    pub processor_claim: Claim<ProcessorColumn>,
+    /// buy insert claim
+    pub buy_insert_claim: Claim<InsertionsColumn>,
+    /// sell insert claim
+    pub sell_insert_claim: Claim<InsertionsColumn>,
+    /// poseidon claim
+    pub poseidon_claim: Claim<PoseidonColumn>,
+    /// strictly less than claim
+    pub strict_less_than_claim: Claim<LessThanColumn>,
+    /// less than claim
+    pub less_than_claim: Claim<LessThanColumn>,
     /// bytes component claim
     pub bytes_claim: Claim<BytesPreProcessedColumn>,
-    // followed by claims for each component
 }
 
+impl VexClaim {
+    /// mix all components log sizes and public inputs into the channel
+    pub fn mix_into(&self, channel: &mut impl Channel) {
+        self.bytes_claim.mix_into(channel);
+        self.poseidon_claim.mix_into(channel);
+        self.strict_less_than_claim.mix_into(channel);
+        self.less_than_claim.mix_into(channel);
+        self.processor_claim.mix_into(channel);
+        self.buy_insert_claim.mix_into(channel);
+        self.sell_insert_claim.mix_into(channel);
+    }
+
+    /// Returns the total log size of all components
+    pub fn log_sizes(&self) -> TreeVec<Vec<u32>> {
+        TreeVec::concat_cols(
+            [
+                self.bytes_claim.log_sizes(),
+                self.poseidon_claim.log_sizes(),
+                self.strict_less_than_claim.log_sizes(),
+                self.less_than_claim.log_sizes(),
+                self.processor_claim.log_sizes(),
+                self.buy_insert_claim.log_sizes(),
+                self.sell_insert_claim.log_sizes(),
+            ]
+            .into_iter(),
+        )
+    }
+}
+
+impl std::fmt::Debug for VexClaim {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VexClaim")
+            .field("initial_state", &self.initial_state)
+            .field("final_state", &self.final_state)
+            .field("processor_log_size", &self.processor_claim.log_size)
+            .field("buy_insert_log_size", &self.buy_insert_claim.log_size)
+            .field("sell_insert_log_size", &self.sell_insert_claim.log_size)
+            .field("poseidon_log_size", &self.poseidon_claim.log_size)
+            .field(
+                "strict_less_than_log_size",
+                &self.strict_less_than_claim.log_size,
+            )
+            .field("less_than_log_size", &self.less_than_claim.log_size)
+            .field("bytes_log_size", &self.bytes_claim.log_size)
+            .finish()
+    }
+}
+
+/// Interaction Claim for the Vex Prover
+/// Contains LogUp Sum for each component
 pub struct VexInteractionClaim {
+    /// Processor component interaction claim
+    pub processor_interaction_claim: InteractionClaim<ProcessorColumn>,
+    /// Buy insert component interaction claim
+    pub buy_insert_interaction_claim: InteractionClaim<InsertionsColumn>,
+    /// Sell insert component interaction claim
+    pub sell_insert_interaction_claim: InteractionClaim<InsertionsColumn>,
+    /// Poseidon component interaction claim
+    pub poseidon_interaction_claim: InteractionClaim<PoseidonColumn>,
+    /// Strictly less than component interaction claim
+    pub strict_less_than_interaction_claim: InteractionClaim<LessThanColumn>,
+    /// Less than component interaction claim
+    pub less_than_interaction_claim: InteractionClaim<LessThanColumn>,
     /// Bytes component interaction claim
     pub bytes_interaction_claim: InteractionClaim<BytesPreProcessedColumn>,
+}
+
+impl VexInteractionClaim {
+    /// mix all logups into the channel
+    pub fn mix_into(&self, channel: &mut impl Channel) {
+        self.bytes_interaction_claim.mix_into(channel);
+        self.poseidon_interaction_claim.mix_into(channel);
+        self.strict_less_than_interaction_claim.mix_into(channel);
+        self.less_than_interaction_claim.mix_into(channel);
+        self.processor_interaction_claim.mix_into(channel);
+        self.buy_insert_interaction_claim.mix_into(channel);
+        self.sell_insert_interaction_claim.mix_into(channel);
+    }
+
+    /// Returns the total logup sum of all components
+    /// Note that the Total LogUp Sum will be Non-Zero
+    /// The Initial State Elements have to yielded and the final state elements have to be used
+    /// SecureField::zero() = interactionclaim.logup_sum() - (initial_state_elements)^(-1) + (final_state_elements)^(-1)
+    pub fn logup_sum(&self) -> SecureField {
+        let mut sum = SecureField::zero();
+        sum += self.processor_interaction_claim.claimed_sum;
+        sum += self.buy_insert_interaction_claim.claimed_sum;
+        sum += self.sell_insert_interaction_claim.claimed_sum;
+        sum += self.poseidon_interaction_claim.claimed_sum;
+        sum += self.strict_less_than_interaction_claim.claimed_sum;
+        sum += self.less_than_interaction_claim.claimed_sum;
+        sum += self.bytes_interaction_claim.claimed_sum;
+        sum
+    }
+}
+
+impl std::fmt::Debug for VexInteractionClaim {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VexInteractionClaim")
+            .field("processor", &self.processor_interaction_claim.claimed_sum)
+            .field("buy_insert", &self.buy_insert_interaction_claim.claimed_sum)
+            .field(
+                "sell_insert",
+                &self.sell_insert_interaction_claim.claimed_sum,
+            )
+            .field("poseidon", &self.poseidon_interaction_claim.claimed_sum)
+            .field(
+                "strict_less_than",
+                &self.strict_less_than_interaction_claim.claimed_sum,
+            )
+            .field("less_than", &self.less_than_interaction_claim.claimed_sum)
+            .field("bytes", &self.bytes_interaction_claim.claimed_sum)
+            .finish()
+    }
 }

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1,0 +1,293 @@
+use num_traits::Zero;
+use stwo_prover::{
+    constraint_framework::{
+        Relation, INTERACTION_TRACE_IDX, ORIGINAL_TRACE_IDX, PREPROCESSED_TRACE_IDX,
+    },
+    core::{
+        backend::simd::SimdBackend,
+        channel::Blake2sChannel,
+        fields::{m31::BaseField, qm31::SecureField, FieldExpOps},
+        pcs::{CommitmentSchemeProver, CommitmentSchemeVerifier, PcsConfig},
+        poly::circle::{CanonicCoset, PolyOps},
+        prover::{self, verify, ProvingError, VerificationError},
+        vcs::blake2_merkle::{Blake2sMerkleChannel, Blake2sMerkleHasher},
+    },
+};
+use tracing::{span, Level};
+
+use crate::{
+    components::{
+        bytes, insertions, is_first, less_than, poseidon, processor, VexComponent, VexComponents,
+        VexInteractionElements,
+    },
+    executor::record::ExecutionTrace,
+    imt::side::{Buy, Sell},
+    VexClaim, VexInteractionClaim, VexProof,
+};
+
+/// Prove the Vex Execution Trace
+pub fn prove_vex(
+    trace: ExecutionTrace<BaseField>,
+) -> Result<VexProof<Blake2sMerkleHasher>, ProvingError> {
+    let _span = span!(Level::INFO, "Prove Vex").entered();
+
+    // default config
+    let config = PcsConfig::default();
+
+    // precompute twiddles for low degree polynomial extension
+    let twiddles = SimdBackend::precompute_twiddles(
+        CanonicCoset::new(trace.max_log_size() + config.fri_config.log_blowup_factor + 2)
+            .circle_domain()
+            .half_coset,
+    );
+
+    // blake2s channel and commitment scheme used in merkle tree
+    let channel = &mut Blake2sChannel::default();
+    let mut commitment_scheme =
+        CommitmentSchemeProver::<_, Blake2sMerkleChannel>::new(config, &twiddles);
+
+    let span = span!(Level::INFO, "Preprocessed Trace").entered();
+    let mut tree_builder = commitment_scheme.tree_builder();
+
+    // Extend the preprocessed trace with the components
+    tree_builder.extend_evals(bytes::preprocessed_trace());
+    tree_builder.extend_evals(is_first(trace.log_size(VexComponent::Poseidon)));
+    tree_builder.extend_evals(is_first(trace.log_size(VexComponent::StrictLessThan)));
+    tree_builder.extend_evals(is_first(trace.log_size(VexComponent::LessThan)));
+    tree_builder.extend_evals(is_first(trace.log_size(VexComponent::Processor)));
+    tree_builder.extend_evals(is_first(trace.log_size(VexComponent::InsertBuyOrder)));
+    tree_builder.extend_evals(is_first(trace.log_size(VexComponent::InsertSellOrder)));
+    tree_builder.commit(channel);
+    span.exit();
+
+    let span = span!(Level::INFO, "Main Trace").entered();
+    let mut tree_builder = commitment_scheme.tree_builder();
+    let (bytes_trace, bytes_claim) = bytes::trace(trace.byte_operations.clone());
+    let (poseidon_trace, poseidon_claim) = poseidon::trace(trace.poseidon_operations);
+    let (strict_less_than_trace, strict_less_than_claim) =
+        less_than::trace_eval::<true>(trace.strict_less_than_operations);
+    let (less_than_trace, less_than_claim) =
+        less_than::trace_eval::<false>(trace.less_than_operations);
+    let (processor_trace, processor_claim) = processor::trace(trace.instructions);
+    let (buy_insert_trace, buy_insert_claim) = insertions::trace::<Buy>(trace.buy_insert_order);
+    let (sell_insert_trace, sell_insert_claim) = insertions::trace::<Sell>(trace.sell_insert_order);
+
+    // Extend the main trace with the components
+    tree_builder.extend_evals(bytes_trace);
+    tree_builder.extend_evals(poseidon_trace.clone());
+    tree_builder.extend_evals(strict_less_than_trace.clone());
+    tree_builder.extend_evals(less_than_trace.clone());
+    tree_builder.extend_evals(processor_trace.clone());
+    tree_builder.extend_evals(buy_insert_trace.clone());
+    tree_builder.extend_evals(sell_insert_trace.clone());
+
+    // create the VexClaim
+    let claim = VexClaim {
+        final_state: trace.final_state,
+        initial_state: trace.initial_state,
+        processor_claim,
+        buy_insert_claim,
+        sell_insert_claim,
+        poseidon_claim,
+        strict_less_than_claim,
+        less_than_claim,
+        bytes_claim,
+    };
+
+    // Mix the claim into the channel.
+    claim.mix_into(channel);
+    // Commit the main trace.
+    tree_builder.commit(channel);
+    span.exit();
+
+    let span = span!(Level::INFO, "Interaction Trace").entered();
+
+    // Draw interaction elements
+    let interaction_elements = VexInteractionElements::draw(channel);
+
+    let mut tree_builder = commitment_scheme.tree_builder();
+    let (bytes_interaction_trace, bytes_interaction_claim) = bytes::interaction_trace(
+        trace.byte_operations,
+        &interaction_elements.and_elements,
+        &interaction_elements.less_than_u8_elements,
+        &interaction_elements.range_check_u8_elements,
+    );
+    let (poseidon_interaction_trace, poseidon_interaction_claim) =
+        poseidon::interaction_trace(&poseidon_trace, &interaction_elements.poseidon_elements);
+    let (processor_interaction_trace, processor_interaction_claim) = processor::interaction_trace(
+        &processor_trace,
+        &interaction_elements.state_elements,
+        &interaction_elements.instruction_elements,
+    );
+    let (strict_less_than_interaction_trace, strict_less_than_interaction_claim) =
+        less_than::interaction_trace_eval::<true, _>(
+            &strict_less_than_trace,
+            &interaction_elements.less_than_u8_elements,
+            &interaction_elements.strict_less_than_elements,
+        );
+    let (less_than_interaction_trace, less_than_interaction_claim) =
+        less_than::interaction_trace_eval::<false, _>(
+            &less_than_trace,
+            &interaction_elements.less_than_u8_elements,
+            &interaction_elements.less_than_elements,
+        );
+    let (buy_insert_interaction_trace, buy_insert_interaction_claim) =
+        insertions::interaction_trace::<Buy>(
+            &buy_insert_trace,
+            &interaction_elements.poseidon_elements,
+            &interaction_elements.less_than_elements,
+            &interaction_elements.strict_less_than_elements,
+            &interaction_elements.instruction_elements,
+        );
+    let (sell_insert_interaction_trace, sell_insert_interaction_claim) =
+        insertions::interaction_trace::<Sell>(
+            &sell_insert_trace,
+            &interaction_elements.poseidon_elements,
+            &interaction_elements.less_than_elements,
+            &interaction_elements.strict_less_than_elements,
+            &interaction_elements.instruction_elements,
+        );
+
+    tree_builder.extend_evals(bytes_interaction_trace);
+    tree_builder.extend_evals(poseidon_interaction_trace);
+    tree_builder.extend_evals(strict_less_than_interaction_trace);
+    tree_builder.extend_evals(less_than_interaction_trace);
+    tree_builder.extend_evals(processor_interaction_trace);
+    tree_builder.extend_evals(buy_insert_interaction_trace);
+    tree_builder.extend_evals(sell_insert_interaction_trace);
+
+    let interaction_claim = VexInteractionClaim {
+        processor_interaction_claim,
+        buy_insert_interaction_claim,
+        sell_insert_interaction_claim,
+        poseidon_interaction_claim,
+        strict_less_than_interaction_claim,
+        less_than_interaction_claim,
+        bytes_interaction_claim,
+    };
+
+    // Mix the interaction claim into the channel.
+    interaction_claim.mix_into(channel);
+
+    // Commit interaction trace.
+    tree_builder.commit(channel);
+    span.exit();
+
+    let span = span!(Level::INFO, "Proof Generation").entered();
+    let component_builder = VexComponents::new(&claim, &interaction_elements, &interaction_claim);
+    let components = component_builder.provers();
+    let proof = prover::prove::<SimdBackend, _>(&components, channel, commitment_scheme)?;
+    span.exit();
+
+    Ok(VexProof {
+        claim,
+        interaction_claim,
+        stark_proof: proof,
+    })
+}
+
+/// Verify VexProof
+pub fn verify_vex(
+    VexProof {
+        claim,
+        interaction_claim,
+        stark_proof,
+    }: VexProof<Blake2sMerkleHasher>,
+) -> Result<(), VerificationError> {
+    let _span = span!(Level::INFO, "Verify").entered();
+
+    // default config
+    let config = PcsConfig::default();
+    let channel = &mut Blake2sChannel::default();
+    let commitment_scheme_verifier =
+        &mut CommitmentSchemeVerifier::<Blake2sMerkleChannel>::new(config);
+    let log_sizes = &claim.log_sizes();
+
+    // preprocessed trace
+    commitment_scheme_verifier.commit(
+        stark_proof.commitments[PREPROCESSED_TRACE_IDX],
+        &log_sizes[PREPROCESSED_TRACE_IDX],
+        channel,
+    );
+
+    // main trace
+    claim.mix_into(channel);
+    commitment_scheme_verifier.commit(
+        stark_proof.commitments[ORIGINAL_TRACE_IDX],
+        &log_sizes[ORIGINAL_TRACE_IDX],
+        channel,
+    );
+
+    // interaction trace
+    let interaction_elements = VexInteractionElements::draw(channel);
+    let initial_state_comb: SecureField = interaction_elements
+        .state_elements
+        .combine(&claim.initial_state);
+    let final_state_comb: SecureField = interaction_elements
+        .state_elements
+        .combine(&claim.final_state);
+    // Check that the lookup sum is valid, otherwise throw
+    if !(interaction_claim.logup_sum() + final_state_comb.inverse() - initial_state_comb.inverse())
+        .is_zero()
+    {
+        return Err(VerificationError::ProofOfWork);
+    };
+    interaction_claim.mix_into(channel);
+    commitment_scheme_verifier.commit(
+        stark_proof.commitments[INTERACTION_TRACE_IDX],
+        &log_sizes[INTERACTION_TRACE_IDX],
+        channel,
+    );
+
+    // Verify the proof
+    let component_builder = VexComponents::new(&claim, &interaction_elements, &interaction_claim);
+    let components = component_builder.components();
+
+    verify(
+        &components,
+        channel,
+        commitment_scheme_verifier,
+        stark_proof,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use rand::Rng;
+    use tracing::{span, Level};
+
+    use crate::{
+        executor::{order_book::OrderBook, record::ExecutionTrace},
+        imt::order::Order,
+    };
+
+    use super::*;
+
+    #[test_log::test]
+    fn test_prove() {
+        // Execution Record
+        let span = span!(Level::INFO, "Generating Execution Record").entered();
+        let record = Rc::new(RefCell::new(ExecutionTrace::new()));
+        let mut order_book = OrderBook::new(Rc::clone(&record));
+        let mut rng = rand::thread_rng();
+        let mut time = 1;
+        let n = 1 << 8;
+        for _ in 0..n {
+            let time_inc = rng.gen_range(1..=16);
+            time += time_inc;
+            let buy_order = Order::new(rng.gen_range(1..=50), rng.gen_range(51..=100), time);
+            let sell_order = Order::new(rng.gen_range(101..=150), rng.gen_range(151..=200), time);
+            order_book.place_buy_order(buy_order).unwrap();
+            order_book.place_sell_order(sell_order).unwrap();
+        }
+
+        let mut execution_trace =
+            std::mem::replace(&mut *record.borrow_mut(), ExecutionTrace::new());
+        execution_trace.final_state = order_book.state().to_felts();
+        span.exit();
+        let proof = prove_vex(execution_trace).unwrap();
+        verify_vex(proof).unwrap();
+    }
+}

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -9,7 +9,7 @@ use stwo_prover::{
         fields::{m31::BaseField, qm31::SecureField, FieldExpOps},
         pcs::{CommitmentSchemeProver, CommitmentSchemeVerifier, PcsConfig},
         poly::circle::{CanonicCoset, PolyOps},
-        prover::{self, verify, ProvingError, VerificationError},
+        prover::{self, verify, ProvingError},
         vcs::blake2_merkle::{Blake2sMerkleChannel, Blake2sMerkleHasher},
     },
 };
@@ -20,6 +20,7 @@ use crate::{
         bytes, insertions, is_first, less_than, poseidon, processor, VexComponent, VexComponents,
         VexInteractionElements,
     },
+    error::VexVerificationError,
     executor::record::ExecutionTrace,
     imt::side::{Buy, Sell},
     VexClaim, VexInteractionClaim, VexProof,
@@ -65,9 +66,8 @@ pub fn prove_vex(
     let (bytes_trace, bytes_claim) = bytes::trace(trace.byte_operations.clone());
     let (poseidon_trace, poseidon_claim) = poseidon::trace(trace.poseidon_operations);
     let (strict_less_than_trace, strict_less_than_claim) =
-        less_than::trace_eval::<true>(trace.strict_less_than_operations);
-    let (less_than_trace, less_than_claim) =
-        less_than::trace_eval::<false>(trace.less_than_operations);
+        less_than::trace::<true>(trace.strict_less_than_operations);
+    let (less_than_trace, less_than_claim) = less_than::trace::<false>(trace.less_than_operations);
     let (processor_trace, processor_claim) = processor::trace(trace.instructions);
     let (buy_insert_trace, buy_insert_claim) = insertions::trace::<Buy>(trace.buy_insert_order);
     let (sell_insert_trace, sell_insert_claim) = insertions::trace::<Sell>(trace.sell_insert_order);
@@ -120,13 +120,13 @@ pub fn prove_vex(
         &interaction_elements.instruction_elements,
     );
     let (strict_less_than_interaction_trace, strict_less_than_interaction_claim) =
-        less_than::interaction_trace_eval::<true, _>(
+        less_than::interaction_trace::<true, _>(
             &strict_less_than_trace,
             &interaction_elements.less_than_u8_elements,
             &interaction_elements.strict_less_than_elements,
         );
     let (less_than_interaction_trace, less_than_interaction_claim) =
-        less_than::interaction_trace_eval::<false, _>(
+        less_than::interaction_trace::<false, _>(
             &less_than_trace,
             &interaction_elements.less_than_u8_elements,
             &interaction_elements.less_than_elements,
@@ -193,7 +193,7 @@ pub fn verify_vex(
         interaction_claim,
         stark_proof,
     }: VexProof<Blake2sMerkleHasher>,
-) -> Result<(), VerificationError> {
+) -> Result<(), VexVerificationError> {
     let _span = span!(Level::INFO, "Verify").entered();
 
     // default config
@@ -226,11 +226,11 @@ pub fn verify_vex(
     let final_state_comb: SecureField = interaction_elements
         .state_elements
         .combine(&claim.final_state);
-    // Check that the lookup sum is valid, otherwise throw
+    // Check that the lookup sum is valid
     if !(interaction_claim.logup_sum() + final_state_comb.inverse() - initial_state_comb.inverse())
         .is_zero()
     {
-        return Err(VerificationError::ProofOfWork);
+        return Err(VexVerificationError::InvalidLogupSum);
     };
     interaction_claim.mix_into(channel);
     commitment_scheme_verifier.commit(
@@ -249,6 +249,7 @@ pub fn verify_vex(
         commitment_scheme_verifier,
         stark_proof,
     )
+    .map_err(VexVerificationError::Stark)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds prover and verifier for VEX
Currently the prove function only supports insertion instructions on both the IMT's
The lookup consistency is verified from the total log up sum in verify_vex function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a refined order management system to enhance buy/sell order processing and improve transaction verification.
	- Rolled out a robust mechanism for generating and validating execution traces, boosting overall system reliability.
- **Refactor**
	- Streamlined core processing components and state management for better modularity and maintainability.
	- Upgraded error handling and reporting to offer clearer feedback and improved operation consistency.
- **Tests**
	- Expanded test coverage to validate order placements, matching operations, and trace interactions for reliable performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->